### PR TITLE
skipped frame reset added

### DIFF
--- a/tracklet/tracklet.py
+++ b/tracklet/tracklet.py
@@ -6,7 +6,7 @@ class Tracklet():
         self._object_id = object_id
         self._boxes = []  # one object (all the boxes)
         self._object_class = object_class  # "PERSON"
-        self._skipped_frames = 0  # count
+        self.skipped_frames = 0  # count
         
 
     def add_box(self, box):
@@ -15,21 +15,36 @@ class Tracklet():
     def increase_skip(self):
         self._skipped_frames += 1
         return self
+    
+    def reset_skipped_frames(self):
+        self._skipped_frames = 0
+
 
     @property
     def skipped_frames(self):
         return self._skipped_frames
+  
+    
+    @skipped_frames.setter
+    def skipped_frames(self, skipped_frames):
+        if skipped_frames < 0:
+            raise ValueError('Number should be positive')
+        else:
+            self._skipped_frames = skipped_frames
+    
 
     @property
     def objectId(self):
         return self._object_id
 
+
     @property
     def object_class(self):
         return self._object_class
 
+
     def __repr__(self):
-        temp_json = {"object_id": self._object_id, "boxes": self._boxes, "skipped_frames": str(self._skipped_frames)}
+        temp_json = {"object_id": self._object_id, "boxes": self._boxes, "skipped_frames": str(self.skipped_frames)}
         return json.dumps(temp_json, indent=4)
 
 

--- a/tracklet/trackletmanager.py
+++ b/tracklet/trackletmanager.py
@@ -24,13 +24,10 @@ class TrackletManager:
                 a_tracklet = Tracklet(objectId, "PERSON")
                 a_tracklet.add_box(object_bbox)
                 self.object_tracker[objectId] = a_tracklet
-
-                self.ts_status_labels[objectId] = self.STATUS_ACTIVE
-                
+                self.ts_status_labels[objectId] = self.STATUS_ACTIVE                
             else:
                 self.object_tracker[objectId].add_box(object_bbox)
                 
-
 
     def detect_skipped_frames(self, objects):
         for k, v in list(self.object_tracker.items()):
@@ -39,12 +36,12 @@ class TrackletManager:
                 # add fake box
                 self.object_tracker[k].add_box([-1, -1, -1, -1, -1])
                 self.ts_status_labels[k] = ""  # pass
-
+            else:
+                v.reset_skipped_frames()
             # if object is at max limit, delete and label inactive.
             if v.skipped_frames == self.max_skipped_frame_allowed:
                 self.ts_status_labels[k] = self.STATUS_INACTIVE
                 del self.object_tracker[k]
-
 
 
     def process_objects(self, objects):
@@ -52,11 +49,8 @@ class TrackletManager:
         Args:
             objects (dict): dict of objects in one frame
         """
-
         self.group_bboxes_for_an_object(objects)
-
         self.detect_skipped_frames(objects)
-
 
         return self.ts_status_labels
         


### PR DESCRIPTION
Skipped frame count should look at consecutive frames. After object detected again if max_skipped_frames_allowed is not reached, skipped frame count is reseted to 0 again.

[testOld.txt](https://github.com/CiscoDeepVision/CiscoDeepVision/files/11174490/testOld.txt)
[testNew.txt](https://github.com/CiscoDeepVision/CiscoDeepVision/files/11174491/testNew.txt)
